### PR TITLE
⚡ Bolt: Memoize GeoLayer to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-10 - Expensive GeoJSON processing in render
+**Learning:** The `GeoLayer` component was re-calculating `groupDistritosByMunicipio` on every render, which involves iterating over all features and creating a Map. This blocks the main thread during map interactions.
+**Action:** Always memoize expensive data transformations in map layers, especially when dealing with large GeoJSON datasets.


### PR DESCRIPTION
💡 What: Memoize `processedGeoJSON`, `layerStyle`, and `outlineStyle` using `useMemo`, and wrap `GeoLayer` component with `React.memo`. Extract `groupDistritosByMunicipio` function.
🎯 Why: Prevents expensive re-calculations and unnecessary re-renders when parent component updates or unrelated state changes, improving map responsiveness.
📊 Impact: Expected to reduce main thread blocking during map interactions, especially on hover or zoom.
🔬 Measurement: Verify with React Profiler or visually inspect map smoothness.

---
*PR created automatically by Jules for task [3465028388349733685](https://jules.google.com/task/3465028388349733685) started by @eliseo-arevalo*