### PR TITLE
⚡ Bolt: Enable tree-shaking for @turf/turf

### DIFF
--- a/src/shared/store/mapStore.ts
+++ b/src/shared/store/mapStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
-import * as turf from '@turf/turf';
+// Optimization: Use named imports to enable tree-shaking and reduce bundle size
+import { bbox as calcBbox, bboxPolygon as calcBboxPolygon, center as calcCenter, distance, point } from '@turf/turf';
 import { LngLat } from 'maplibre-gl';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { FeatureProperties } from '../types/feature-propoerties';
@@ -73,14 +74,14 @@ export const useMapStore = create<MapState>((set) => ({
         // Calculate zoom asynchronously to avoid blocking
         requestAnimationFrame(() => {
           try {
-            const bbox = turf.bbox(cleanGeojson);
-            const bboxPolygon = turf.bboxPolygon(bbox);
-            const center = turf.center(bboxPolygon);
+            const bbox = calcBbox(cleanGeojson);
+            const bboxPolygon = calcBboxPolygon(bbox);
+            const center = calcCenter(bboxPolygon);
             const centerCoords = center.geometry.coordinates as [number, number];
             
-            const diagonal = turf.distance(
-              turf.point([bbox[0], bbox[1]]),
-              turf.point([bbox[2], bbox[3]]),
+            const diagonal = distance(
+              point([bbox[0], bbox[1]]),
+              point([bbox[2], bbox[3]]),
               { units: 'kilometers' }
             );
             


### PR DESCRIPTION
💡 What: Replaced wildcard import of `@turf/turf` with named imports in `src/shared/store/mapStore.ts`.
🎯 Why: Importing the entire library as a namespace object (`import * as turf`) can prevent tree-shaking in some bundlers or configurations, leading to larger bundle sizes. Named imports (`import { bbox, ... }`) are explicitly tree-shakeable.
📊 Impact: Reduces the bundle size by excluding unused Turf modules.
🔬 Measurement: Verify with `pnpm build` and checking the bundle analysis (if available) or simply by observing that the application still functions correctly.

---
*PR created automatically by Jules for task [3349481639494009913](https://jules.google.com/task/3349481639494009913) started by @eliseo-arevalo*