### PR TITLE
⚡ Bolt: Optimize Turf.js imports for better tree-shaking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal
+
+## 2024-09-08 - Turf.js Tree Shaking Effectiveness
+**Learning:** Replacing `import * as turf from '@turf/turf'` with named imports in this Vite/Rollup project did not result in any measurable bundle size reduction (size remained exactly 138.80 kB). This suggests Rollup's tree-shaking was already effective with the wildcard import, or the monolithic `@turf/turf` package structure limits further optimization without switching to modular `@turf/package` dependencies.
+**Action:** Always verify bundle size reduction before claiming optimization success. For Turf.js, consider switching to scoped packages (e.g., `@turf/bbox`) if named imports don't yield results.

--- a/src/shared/components/Map/Features/BottomSheet/RouteInfo.tsx
+++ b/src/shared/components/Map/Features/BottomSheet/RouteInfo.tsx
@@ -5,7 +5,7 @@ import { useParadasStore } from '../../../../store/paradasStore';
 import { useMapStore } from '../../../../store/mapStore';
 import { RouteCodeBadge } from '../../../rutas/RouteCodeBadge';
 import type { RutaFeature } from '../../../../types/rutas';
-import * as turf from '@turf/turf';
+import { bbox as turfBbox, bboxPolygon, center as turfCenter } from '@turf/turf';
 
 interface RouteInfoProps {
   route: RutaFeature;
@@ -23,8 +23,8 @@ export const RouteInfo: React.FC<RouteInfoProps> = React.memo(({ route }) => {
   useEffect(() => {
     if (route && !hasZoomedRef.current) {
       try {
-        const bbox = turf.bbox(route);
-        const center = turf.center(turf.bboxPolygon(bbox));
+        const bbox = turfBbox(route);
+        const center = turfCenter(bboxPolygon(bbox));
         const [lng, lat] = center.geometry.coordinates;
         
         updateConfig({

--- a/src/shared/store/mapStore.ts
+++ b/src/shared/store/mapStore.ts
@@ -1,6 +1,6 @@
 'use client';
 import { create } from 'zustand';
-import * as turf from '@turf/turf';
+import { bbox as turfBbox, bboxPolygon as turfBboxPolygon, center as turfCenter, distance, point } from '@turf/turf';
 import { LngLat } from 'maplibre-gl';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { FeatureProperties } from '../types/feature-propoerties';
@@ -88,14 +88,14 @@ export const useMapStore = create<MapState>((set, get) => ({
         // Calculate zoom asynchronously to avoid blocking
         requestAnimationFrame(() => {
           try {
-            const bbox = turf.bbox(cleanGeojson);
-            const bboxPolygon = turf.bboxPolygon(bbox);
-            const center = turf.center(bboxPolygon);
+            const bbox = turfBbox(cleanGeojson);
+            const bboxPolygon = turfBboxPolygon(bbox);
+            const center = turfCenter(bboxPolygon);
             const centerCoords = center.geometry.coordinates as [number, number];
             
-            const diagonal = turf.distance(
-              turf.point([bbox[0], bbox[1]]),
-              turf.point([bbox[2], bbox[3]]),
+            const diagonal = distance(
+              point([bbox[0], bbox[1]]),
+              point([bbox[2], bbox[3]]),
               { units: 'kilometers' }
             );
             


### PR DESCRIPTION
💡 **What**: Replaced wildcard imports (`import * as turf`) with named imports (`import { bbox, ... }`) in `RouteInfo.tsx` and `mapStore.ts`.
🎯 **Why**: Using wildcard imports can prevent effective tree-shaking, potentially including the entire Turf.js library in the bundle. Named imports allow bundlers to strip unused code more reliably.
📊 **Impact**: Enables better dead code elimination. While current bundle size reduction might be minimal (possibly due to existing optimizations or library structure), this ensures future-proof efficiency and clearer dependency usage.
🔬 **Measurement**: Verified with `pnpm build` and `pnpm lint`. No regressions introduced. Bundle size remained constant at 138.80 kB, indicating the bundler was already handling the wildcard import efficiently or the library structure limits further gains without sub-packages.

---
*PR created automatically by Jules for task [1858531007519434364](https://jules.google.com/task/1858531007519434364) started by @eliseo-arevalo*