### PR TITLE
⚡ Bolt: Optimize RouteInfo re-renders and use named imports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2025-03-09 - Zustand Store Selectors
+**Learning:** `useMapStore()` without selectors causes components to re-render on EVERY state change (like map viewport updates), which is devastating for performance in `RouteInfo` and other components subscribed to the store. Always use `useStore(state => state.selector)` to prevent this.
+**Action:** When using Zustand stores, always use selectors to pick only the necessary state slices or actions.
+**Learning:** `import * as turf from '@turf/turf'` was surprisingly well-optimized by Vite/Rollup (bundle size didn't change significantly), suggesting modern bundlers are smart enough to tree-shake even wildcard imports for some libraries.
+**Action:** Prioritize logical optimizations (re-renders) over micro-optimizations (imports) unless bundle size is critical.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,5 +1,0 @@
-## 2025-03-09 - Zustand Store Selectors
-**Learning:** `useMapStore()` without selectors causes components to re-render on EVERY state change (like map viewport updates), which is devastating for performance in `RouteInfo` and other components subscribed to the store. Always use `useStore(state => state.selector)` to prevent this.
-**Action:** When using Zustand stores, always use selectors to pick only the necessary state slices or actions.
-**Learning:** `import * as turf from '@turf/turf'` was surprisingly well-optimized by Vite/Rollup (bundle size didn't change significantly), suggesting modern bundlers are smart enough to tree-shake even wildcard imports for some libraries.
-**Action:** Prioritize logical optimizations (re-renders) over micro-optimizations (imports) unless bundle size is critical.

--- a/src/shared/components/Map/Features/BottomSheet/RouteInfo.tsx
+++ b/src/shared/components/Map/Features/BottomSheet/RouteInfo.tsx
@@ -5,7 +5,7 @@ import { useParadasStore } from '../../../../store/paradasStore';
 import { useMapStore } from '../../../../store/mapStore';
 import { RouteCodeBadge } from '../../../rutas/RouteCodeBadge';
 import type { RutaFeature } from '../../../../types/rutas';
-import * as turf from '@turf/turf';
+import { bbox, bboxPolygon, center } from '@turf/turf';
 
 interface RouteInfoProps {
   route: RutaFeature;
@@ -15,7 +15,9 @@ export const RouteInfo: React.FC<RouteInfoProps> = React.memo(({ route }) => {
   const clearSelectedRoute = useRutasStore(state => state.clearSelectedRoute);
   const paradasByRuta = useParadasStore(state => state.paradasByRuta);
   const setSelectedParada = useParadasStore(state => state.setSelectedParada);
-  const { saveViewport, restoreViewport, updateConfig } = useMapStore();
+  const saveViewport = useMapStore(state => state.saveViewport);
+  const restoreViewport = useMapStore(state => state.restoreViewport);
+  const updateConfig = useMapStore(state => state.updateConfig);
   const props = route.properties;
   const hasZoomedRef = useRef(false);
 
@@ -23,9 +25,9 @@ export const RouteInfo: React.FC<RouteInfoProps> = React.memo(({ route }) => {
   useEffect(() => {
     if (route && !hasZoomedRef.current) {
       try {
-        const bbox = turf.bbox(route);
-        const center = turf.center(turf.bboxPolygon(bbox));
-        const [lng, lat] = center.geometry.coordinates;
+        const routeBbox = bbox(route);
+        const routeCenter = center(bboxPolygon(routeBbox));
+        const [lng, lat] = routeCenter.geometry.coordinates;
         
         updateConfig({
           center: { lat, lng },

--- a/src/shared/store/mapStore.ts
+++ b/src/shared/store/mapStore.ts
@@ -1,6 +1,6 @@
 'use client';
 import { create } from 'zustand';
-import * as turf from '@turf/turf';
+import { bbox, bboxPolygon, center, distance, point } from '@turf/turf';
 import { LngLat } from 'maplibre-gl';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { FeatureProperties } from '../types/feature-propoerties';
@@ -88,14 +88,14 @@ export const useMapStore = create<MapState>((set, get) => ({
         // Calculate zoom asynchronously to avoid blocking
         requestAnimationFrame(() => {
           try {
-            const bbox = turf.bbox(cleanGeojson);
-            const bboxPolygon = turf.bboxPolygon(bbox);
-            const center = turf.center(bboxPolygon);
-            const centerCoords = center.geometry.coordinates as [number, number];
+            const geojsonBbox = bbox(cleanGeojson);
+            const geojsonBboxPolygon = bboxPolygon(geojsonBbox);
+            const geojsonCenter = center(geojsonBboxPolygon);
+            const centerCoords = geojsonCenter.geometry.coordinates as [number, number];
             
-            const diagonal = turf.distance(
-              turf.point([bbox[0], bbox[1]]),
-              turf.point([bbox[2], bbox[3]]),
+            const diagonal = distance(
+              point([geojsonBbox[0], geojsonBbox[1]]),
+              point([geojsonBbox[2], geojsonBbox[3]]),
               { units: 'kilometers' }
             );
             


### PR DESCRIPTION
💡 What:
1. Replaced wildcard imports (`import * as turf`) with named imports (`import { bbox, ... }`) in `RouteInfo.tsx` and `mapStore.ts`.
2. Optimized `RouteInfo.tsx` to use `zustand` selectors instead of destructuring the whole store object.

🎯 Why:
1. Improve tree-shakeability and code cleanliness.
2. Prevent unnecessary re-renders of `RouteInfo` when map viewport changes (e.g. dragging/zooming), which was previously causing performance degradation.

📊 Impact:
- Reduces unnecessary re-renders of `RouteInfo` component significantly during map interaction.
- Potentially reduces bundle size slightly.

🔬 Measurement:
- Verify by using React DevTools Profiler while dragging the map with `RouteInfo` open. Re-renders should be minimized.
- Verify by running `pnpm build`.

---
*PR created automatically by Jules for task [11488509496092735478](https://jules.google.com/task/11488509496092735478) started by @eliseo-arevalo*